### PR TITLE
Fix reader name and adjust dataconverter for new NXopt version

### DIFF
--- a/examples/eln_data.yaml
+++ b/examples/eln_data.yaml
@@ -7,44 +7,46 @@ Data:
   spectrum_type: wavelength
   spectrum_unit: angstrom
 Instrument:
-  Beam_path:
-    Detector:
-      count_time:
-        unit: s
-        value: 1.0
-      detector_type: CCD spectrometer
-    focussing_probes:
-      angular_spread:
-        unit: rad
-        value: 0.2
-      data_correction: false
-    light_source:
-      source_type: arc lamp
-    rotating_element:
-      revolutions: 50.0
+  Detector:
+    count_time:
+      unit: s
+      value: 1.0
+    detector_type: CCD spectrometer
+  focussing_probes:
+    angular_spread:
+      unit: rad
+      value: 0.2
+    data_correction: false
+  light_source:
+    source_type: arc lamp
+  rotating_element:
+    revolutions: 50.0
   Sample_stage:
     environment_conditions:
-      medium: air
     stage_type: manual stage
-  angle_of_incidence/@unit: degrees
-  calibration_status: no calibration
-  company: J. A. Woollam Co.
+#  angle_of_incidence/@unit: degrees
+  device_information:
+    vendor: J. A. Woollam Co.
+    model: RC2 (Vers. 0.0.1)
   ellipsometer_type: dual compensator
-  model: RC2
-  model/@version: 0.0.1
   rotating_element_type: compensator (source side)
-  software: CompleteEASE
-  software/@url: https://www.jawoollam.com/ellipsometry-software/completeease
-  software/version: '6.37'
+  software_RC2: CompleteEASE
+  software_RC2/@url: https://www.jawoollam.com/ellipsometry-software/completeease
+  software_RC2/@version: '6.37'
+  instrument_calibration_RC2:
+    calibration_status: no calibration
 Sample:
   atom_types: Si, O
   backside_roughness: false
   chemical_formula: SiO2
   layer_structure: 2nm SiO2 on Si
-  sample_history: Commercially purchased sample
   sample_name: 2nm SiO2 on Si
-  sample_type: multi layer
+  physical_form: multi layer
   substrate: Si
+  environment:
+    sample_medium: air
+  history:
+    notes: Commercially purchased sample
 User:
   address: Zum Großen Windkanal 2, 12489 Berlin, Germany
   affiliation: Humboldt-Universität zu Berlin
@@ -60,10 +62,14 @@ colnames:
 - err.Delta
 derived_parameter_type: depolarization
 experiment_description: RC2 scan on 2nm SiO2 on Si in air
-experiment_identifier: exp-ID
-experiment_type: NIR-Vis-UV spectroscopic ellipsometry
+experiment_identifier:
+  identifier: exp-ID
+  is_persistent: "false"
+experiment_type: ellipsometry
+ellipsometry_experiment_type: NIR-Vis-UV spectroscopic ellipsometry
 filename: test-data.dat
 plot_name: Psi and Delta
+title: RC2 Ellipsometry of 2nm SiO2 on Si
 sep: \t
 skip: 3
 start_time: '2022-01-27T03:35:00+00:00'

--- a/pynxtools_ellips/reader.py
+++ b/pynxtools_ellips/reader.py
@@ -52,8 +52,8 @@ CONVERT_DICT = {
     "depolarization": "derived_parameters/depolarization",
     "measured_data": "data_collection/measured_data",
     "data_software": "software_TYPE[data_software]/program",
-    "experiment_identifier/identifier":"IDENTIFIER[experiment_identifier]/IDENTIFIER[identifier]",
-    "experiment_identifier/is_persistent":"IDENTIFIER[experiment_identifier]/IS_PERSISTENT[is_persistent]",
+    "experiment_identifier/identifier": "IDENTIFIER[experiment_identifier]/IDENTIFIER[identifier]",
+    "experiment_identifier/is_persistent": "IDENTIFIER[experiment_identifier]/IS_PERSISTENT[is_persistent]",
     "software_RC2": "software_TYPE[software_RC2]/program",
     "software_RC2/@url": "software_TYPE[software_RC2]/program/@url",
     "software_RC2/@version": "software_TYPE[software_RC2]/program/@version",
@@ -61,8 +61,8 @@ CONVERT_DICT = {
     "instrument_calibration_RC2/calibration_status": "instrument_calibration_DEVICE[instrument_calibration_RC2]/calibration_status",
     "environment": "ENVIRONMENT[environment_sample]",
     "history/notes": "HISTORY[history]/notes",
-    "light_source" : "source_TYPE[source_light]", 
-    "source_type" : "type",
+    "light_source": "source_TYPE[source_light]",
+    "source_type": "type",
 }
 
 CONFIG_KEYS = [
@@ -433,9 +433,9 @@ class EllipsometryReader(BaseReader):
                 # using a proper unit parsing logic
                 template[f"/ENTRY[entry]/data_collection/DATA[{key}]/@units"] = "degree"
                 if dindx == 0 and index == 0:
-                    template[f"/ENTRY[entry]/data_collection/DATA[{key}]/@long_name"] = (
-                        f"{plot_name} (degree)"
-                    )
+                    template[
+                        f"/ENTRY[entry]/data_collection/DATA[{key}]/@long_name"
+                    ] = f"{plot_name} (degree)"
                 template[f"/ENTRY[entry]/data_collection/DATA[{key}_errors]"] = {
                     "link": "/entry/data_collection/data_error",
                     "shape": np.index_exp[index, dindx, :],
@@ -453,7 +453,9 @@ class EllipsometryReader(BaseReader):
         # if len(data_list[0]) > 1:
         template["/ENTRY[entry]/data_collection/@auxiliary_signals"] = data_list[0][1:]
         for index in range(1, len(data_list)):
-            template["/ENTRY[entry]/data_collection/@auxiliary_signals"] += data_list[index]
+            template["/ENTRY[entry]/data_collection/@auxiliary_signals"] += data_list[
+                index
+            ]
 
         template["/ENTRY[entry]/definition"] = "NXellipsometry"
         template["/ENTRY[entry]/definition/@url"] = (
@@ -461,14 +463,18 @@ class EllipsometryReader(BaseReader):
             f"blob/{get_nexus_version_hash()}/contributed_definitions/NXellipsometry.nxdl.xml"
         )
         template["/ENTRY[entry]/definition/@version"] = get_nexus_version()
-        template["/ENTRY[entry]/INSTRUMENT[instrument]/software_TYPE[software_NeXuS]/program"] = "pynxtools"
+        template[
+            "/ENTRY[entry]/INSTRUMENT[instrument]/software_TYPE[software_NeXuS]/program"
+        ] = "pynxtools"
         try:
-            template["/ENTRY[entry]/INSTRUMENT[instrument]/software_TYPE[software_NeXuS]/program/@version"] = version("pynxtools")
+            template[
+                "/ENTRY[entry]/INSTRUMENT[instrument]/software_TYPE[software_NeXuS]/program/@version"
+            ] = version("pynxtools")
         except PackageNotFoundError:
             pass
-        template["/ENTRY[entry]/INSTRUMENT[instrument]/software_TYPE[software_NeXuS]/program/@url"] = (
-            "https://github.com/FAIRmat-NFDI/pynxtools"
-        )
+        template[
+            "/ENTRY[entry]/INSTRUMENT[instrument]/software_TYPE[software_NeXuS]/program/@url"
+        ] = "https://github.com/FAIRmat-NFDI/pynxtools"
 
         return template
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 ]
 
 [project.entry-points."pynxtools.reader"]
-ellips = "pynxtools_ellips.reader:ELLIPSReader"
+ellips = "pynxtools_ellips.reader:EllipsometryReader"
 
 [project.urls]
 "Homepage" = "https://github.com/FAIRmat-NFDI/pynxtools-ellips"

--- a/tests/data/eln_data.yaml
+++ b/tests/data/eln_data.yaml
@@ -7,44 +7,46 @@ Data:
   spectrum_type: wavelength
   spectrum_unit: angstrom
 Instrument:
-  Beam_path:
-    Detector:
-      count_time:
-        unit: s
-        value: 1.0
-      detector_type: CCD spectrometer
-    focussing_probes:
-      angular_spread:
-        unit: rad
-        value: 0.2
-      data_correction: false
-    light_source:
-      source_type: arc lamp
-    rotating_element:
-      revolutions: 50.0
+  Detector:
+    count_time:
+      unit: s
+      value: 1.0
+    detector_type: CCD spectrometer
+  focussing_probes:
+    angular_spread:
+      unit: rad
+      value: 0.2
+    data_correction: false
+  light_source:
+    source_type: arc lamp
+  rotating_element:
+    revolutions: 50.0
   Sample_stage:
     environment_conditions:
-      medium: air
     stage_type: manual stage
-  angle_of_incidence/@unit: degrees
-  calibration_status: no calibration
-  company: J. A. Woollam Co.
+#  angle_of_incidence/@unit: degrees
+  device_information:
+    vendor: J. A. Woollam Co.
+    model: RC2 (Vers. 0.0.1)
   ellipsometer_type: dual compensator
-  model: RC2
-  model/@version: 0.0.1
   rotating_element_type: compensator (source side)
-  software: CompleteEASE
-  software/@url: https://www.jawoollam.com/ellipsometry-software/completeease
-  software/version: '6.37'
+  software_RC2: CompleteEASE
+  software_RC2/@url: https://www.jawoollam.com/ellipsometry-software/completeease
+  software_RC2/@version: '6.37'
+  instrument_calibration_RC2:
+    calibration_status: no calibration
 Sample:
   atom_types: Si, O
   backside_roughness: false
   chemical_formula: SiO2
   layer_structure: 2nm SiO2 on Si
-  sample_history: Commercially purchased sample
   sample_name: 2nm SiO2 on Si
-  sample_type: multi layer
+  physical_form: multi layer
   substrate: Si
+  environment:
+    sample_medium: air
+  history:
+    notes: Commercially purchased sample
 User:
   address: Zum Großen Windkanal 2, 12489 Berlin, Germany
   affiliation: Humboldt-Universität zu Berlin
@@ -60,10 +62,14 @@ colnames:
 - err.Delta
 derived_parameter_type: depolarization
 experiment_description: RC2 scan on 2nm SiO2 on Si in air
-experiment_identifier: exp-ID
-experiment_type: NIR-Vis-UV spectroscopic ellipsometry
+experiment_identifier:
+  identifier: exp-ID
+  is_persistent: "false"
+experiment_type: ellipsometry
+ellipsometry_experiment_type: NIR-Vis-UV spectroscopic ellipsometry
 filename: test-data.dat
 plot_name: Psi and Delta
+title: RC2 Ellipsometry of 2nm SiO2 on Si
 sep: \t
 skip: 3
 start_time: '2022-01-27T03:35:00+00:00'


### PR DESCRIPTION
1. In pyproject.toml the reader name was adjusted, who revert fully the renaming during setting up this repository.
2. the ellipsometry reader was adjusted, to be in line with the new NXopt definition - mostly renaming and resorting some structures.
3. The eln_data.yaml file had to be adjusted at some points. The creation of this meta data will be fixed next.