### PR TITLE
remove camel case notation from reader and eln_data

### DIFF
--- a/examples/eln_data.yaml
+++ b/examples/eln_data.yaml
@@ -6,7 +6,7 @@ Data:
   data_type: Psi/Delta
   spectrum_type: wavelength
   spectrum_unit: angstrom
-Instrument:
+instrument:
   beam_source:
     parameter_reliability: nominal
     incident_wavelength:
@@ -15,7 +15,7 @@ Instrument:
       - 1700
       unit: nm
     associated_source: entry/instrument/source_light
-  Detector:
+  detector:
     count_time:
       unit: s
       value: 1.0
@@ -45,7 +45,7 @@ Instrument:
   software_RC2/@version: '6.37'
   instrument_calibration_RC2:
     calibration_status: no calibration
-Sample:
+sample:
   atom_types: Si, O
   backside_roughness: false
   chemical_formula: SiO2
@@ -58,7 +58,7 @@ Sample:
   history:
     notes:
       description: Commercially purchased sample
-User:
+user:
   address: Zum Großen Windkanal 2, 12489 Berlin, Germany
   affiliation: Humboldt-Universität zu Berlin
   email: surname.name@physik.hu-berlin.de

--- a/pynxtools_ellips/reader.py
+++ b/pynxtools_ellips/reader.py
@@ -37,16 +37,16 @@ DEFAULT_HEADER = {"sep": "\t", "skip": 0}
 
 CONVERT_DICT = {
     "unit": "@units",
-    "Detector": "detector_TYPE[detector_ccd]",
+    "detector": "detector_TYPE[detector_ccd]",
     "Data": "data_collection",
     "derived_parameters": "derived_parameters",
     "environment": "environment_conditions",
-    "Instrument": "INSTRUMENT[instrument]",
-    "Sample": "SAMPLE[sample]",
-    "Sample_stage": "sample_stage",
-    "User": "USER[user]",
-    "Instrument/angle_of_incidence": "INSTRUMENT[instrument]/angle_of_incidence",
-    "Instrument/angle_of_incidence/unit": "INSTRUMENT[instrument]/angle_of_incidence/@units",
+    "instrument": "INSTRUMENT[instrument]",
+    "sample": "SAMPLE[sample]",
+    "sample_stage": "sample_stage",
+    "user": "USER[user]",
+    "instrument/angle_of_incidence": "INSTRUMENT[instrument]/angle_of_incidence",
+    "instrument/angle_of_incidence/unit": "INSTRUMENT[instrument]/angle_of_incidence/@units",
     "column_names": "data_collection/column_names",
     "data_error": "data_collection/data_error",
     "depolarization": "derived_parameters/depolarization",
@@ -370,9 +370,9 @@ class EllipsometryReader(BaseReader):
         if is_mock:
             header, labels = mock_function(header)
 
-        if "atom_types" not in header["Sample"]:
+        if "atom_types" not in header["sample"]:
             header["atom_types"] = extract_atom_types(
-                header["Sample"]["chemical_formula"]
+                header["sample"]["chemical_formula"]
             )
 
         return header, labels

--- a/tests/data/eln_data.yaml
+++ b/tests/data/eln_data.yaml
@@ -6,7 +6,7 @@ Data:
   data_type: Psi/Delta
   spectrum_type: wavelength
   spectrum_unit: angstrom
-Instrument:
+instrument:
   beam_source:
     parameter_reliability: nominal
     incident_wavelength:
@@ -15,7 +15,7 @@ Instrument:
       - 1700
       unit: nm
     associated_source: entry/instrument/source_light
-  Detector:
+  detector:
     count_time:
       unit: s
       value: 1.0
@@ -45,7 +45,7 @@ Instrument:
   software_RC2/@version: '6.37'
   instrument_calibration_RC2:
     calibration_status: no calibration
-Sample:
+sample:
   atom_types: Si, O
   backside_roughness: false
   chemical_formula: SiO2
@@ -58,7 +58,7 @@ Sample:
   history:
     notes:
       description: Commercially purchased sample
-User:
+user:
   address: Zum Großen Windkanal 2, 12489 Berlin, Germany
   affiliation: Humboldt-Universität zu Berlin
   email: surname.name@physik.hu-berlin.de


### PR DESCRIPTION
small changes to remove camel case notation from eln_data files and the reader.

this is done to be in line with the eln_data generation by nomad. Only the "Data" entry is left camel case, as it is for the eln_data generation nomad.