### PR TITLE
fix lamp type for new nexus def

### DIFF
--- a/examples/eln_data.yaml
+++ b/examples/eln_data.yaml
@@ -28,7 +28,7 @@ instrument:
     data_correction: false
     type: objective
   light_source:
-    type: arc lamp
+    type: Xenon Lamp
   rotating_element:
     revolutions:
       value: 50.0

--- a/tests/data/eln_data.yaml
+++ b/tests/data/eln_data.yaml
@@ -28,7 +28,7 @@ instrument:
     data_correction: false
     type: objective
   light_source:
-    type: arc lamp
+    type: Xenon Lamp
   rotating_element:
     revolutions:
       value: 50.0


### PR DESCRIPTION
This should be the right fix to consider the latest upate of the nexus defnitions to fix [this](https://github.com/FAIRmat-NFDI/pynxtools/actions/runs/12052264659/job/33649741968),
BUT the CI/CD fails, as it uses the old nexus definitions.. 
CI/CD could be bypassed and merged anyway. OR how can I set up the CI/CD to use the specific pynxtools branch?